### PR TITLE
Add ClauseMind service

### DIFF
--- a/src/app/api/clausemind/route.ts
+++ b/src/app/api/clausemind/route.ts
@@ -1,0 +1,41 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+export async function POST(request: NextRequest) {
+  const { action, text } = await request.json()
+  if (!action || !text) {
+    return NextResponse.json({ error: 'Invalid request' }, { status: 400 })
+  }
+
+  const prompts: Record<string, string> = {
+    explain: `Explain this clause in simple terms:\n\n${text}`,
+    rewrite: `Rewrite the following clause for clarity:\n\n${text}`,
+    simplify: `Simplify this clause:\n\n${text}`
+  }
+
+  const apiKey = process.env.OPENAI_API_KEY
+  if (!apiKey) {
+    return NextResponse.json({ error: 'Missing API key' }, { status: 500 })
+  }
+
+  const res = await fetch('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`
+    },
+    body: JSON.stringify({
+      model: 'gpt-3.5-turbo',
+      messages: [{ role: 'user', content: prompts[action] }],
+      temperature: 0.7
+    })
+  })
+
+  if (!res.ok) {
+    const error = await res.text()
+    return NextResponse.json({ error }, { status: 500 })
+  }
+
+  const data = await res.json()
+  const result = data.choices?.[0]?.message?.content?.trim()
+  return NextResponse.json({ result })
+}

--- a/src/app/dashboard/clausemind/page.tsx
+++ b/src/app/dashboard/clausemind/page.tsx
@@ -1,0 +1,87 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { supabase } from '@/lib/supabaseClient'
+
+export default function ClauseMindPage() {
+  const router = useRouter()
+  const [authChecked, setAuthChecked] = useState(false)
+  const [clause, setClause] = useState('')
+  const [result, setResult] = useState('')
+  const [loading, setLoading] = useState(false)
+
+  useEffect(() => {
+    const checkAuth = async () => {
+      const { data: { user } } = await supabase.auth.getUser()
+      if (!user) router.push('/login')
+      setAuthChecked(true)
+    }
+    checkAuth()
+  }, [router])
+
+  const handleAction = async (action: 'explain' | 'rewrite' | 'simplify') => {
+    if (!clause.trim()) return
+    setLoading(true)
+    setResult('')
+    try {
+      const res = await fetch('/api/clausemind', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action, text: clause })
+      })
+      const data = await res.json()
+      if (res.ok) setResult(data.result)
+      else setResult(data.error || 'Request failed')
+    } catch (err) {
+      setResult('Request failed')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  if (!authChecked) {
+    return <div className="max-w-4xl mx-auto px-6 py-16">Loading...</div>
+  }
+
+  return (
+    <section className="max-w-4xl mx-auto px-6 py-16 space-y-6">
+      <h1 className="text-3xl font-bold text-primary">ClauseMind</h1>
+      <p className="text-gray-700">AI-assisted clause editor</p>
+      <textarea
+        value={clause}
+        onChange={e => setClause(e.target.value)}
+        className="w-full h-40 p-3 border rounded"
+        placeholder="Paste a contract clause here..."
+      />
+      <div className="space-x-4">
+        <button
+          onClick={() => handleAction('explain')}
+          disabled={loading}
+          className="bg-primary text-white px-4 py-2 rounded hover:bg-primary-hover"
+        >
+          Explain
+        </button>
+        <button
+          onClick={() => handleAction('rewrite')}
+          disabled={loading}
+          className="bg-primary text-white px-4 py-2 rounded hover:bg-primary-hover"
+        >
+          Rewrite
+        </button>
+        <button
+          onClick={() => handleAction('simplify')}
+          disabled={loading}
+          className="bg-primary text-white px-4 py-2 rounded hover:bg-primary-hover"
+        >
+          Simplify
+        </button>
+      </div>
+      {result && (
+        <div className="border rounded p-4 bg-gray-50 whitespace-pre-wrap">
+          {result}
+        </div>
+      )}
+    </section>
+  )
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -58,6 +58,17 @@ export default function Dashboard() {
           View Tenders
         </Link>
       </div>
+
+      <div className="mt-8 bg-white p-6 rounded-lg shadow border space-y-4">
+        <h2 className="text-xl font-bold text-primary">ClauseMind</h2>
+        <p className="text-gray-700">Draft contracts with AI assistance</p>
+        <Link
+          href="/dashboard/clausemind"
+          className="inline-block bg-primary text-white px-6 py-2 rounded hover:bg-primary-hover transition-colors"
+        >
+          Open ClauseMind
+        </Link>
+      </div>
     </section>
   );
 }


### PR DESCRIPTION
## Summary
- add ClauseMind link on dashboard
- create clause editor page with AI actions
- add API route to query OpenAI

## Testing
- `npm install` *(fails: unable to reach registry)*

------
https://chatgpt.com/codex/tasks/task_e_688001c2d190833180aae09fef0e5e6e