### PR TITLE
Fix Next.js route handler types

### DIFF
--- a/src/app/api/contracts/[id]/export/route.ts
+++ b/src/app/api/contracts/[id]/export/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server'
 import { supabaseAdmin } from '@/lib/supabaseAdmin'
 import { pdf } from '@react-pdf/renderer'
+import React from 'react'
 import ContractPDF from '@/components/pdf/ContractPDF'
 import { globalLimiter } from '@/lib/rateLimit'
 import { track } from '@/lib/analytics'
@@ -9,8 +10,9 @@ import type { NextRequest } from 'next/server'
 
 export async function GET(
   request: NextRequest,
-  { params }: { params: { id: string } }
+  context: { params: { id: string } }
 ) {
+  const { params } = context
   const ip = request.headers.get('x-forwarded-for') || 'global'
   if (!globalLimiter.check(ip)) {
     return NextResponse.json({ error: 'Rate limit exceeded' }, { status: 429 })
@@ -22,7 +24,10 @@ export async function GET(
   }
 
   const clauses = (data.content ? JSON.parse(data.content) : []) as { text: string }[]
-  const doc = <ContractPDF title={data.title} clauses={clauses} />
+  const doc = React.createElement(ContractPDF, {
+    title: data.title,
+    clauses,
+  })
   const blob = await pdf(doc).toBuffer()
   track('contract_exported', { id })
   return new NextResponse(blob as unknown as BodyInit, {


### PR DESCRIPTION
## Summary
- update route GET handler to use a context parameter

## Testing
- `npm test`
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_688025e1c0a48331bc1d4c7054081686